### PR TITLE
Waypoint Integration

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/SpawnBroadcaster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/SpawnBroadcaster.kt
@@ -5,7 +5,7 @@ import com.cobblemon.mod.common.api.spawning.detail.SpawnPool
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
-import net.minecraft.util.Identifier
+import net.minecraft.util.Identifier    
 import net.minecraft.util.math.BlockPos
 import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
 
@@ -66,6 +66,25 @@ class SpawnBroadcaster(
             if (config.broadcastPlayerSpawnedOn && player != null) config.getComponent(
                 "notification.player",
                 player.name
+            ) else "",
+            if (config.broadcastWaypoints) config.getComponent(
+                "notification.waypoints", 
+                if (shiny && config.broadcastShiny) config.getComponent(
+                    "notification.shiny",
+                    config.getComponent("shiny")
+                ) else "",
+                if (label != null) config.getComponent(
+                    "notification.label",
+                    config.getComponent("label.$label")
+                ) else "",
+                if (bucket != null) config.getComponent(
+                    "notification.bucket",
+                    config.getComponent("bucket.$bucket")
+                ) else "",
+                if (config.broadcastSpeciesName) pokemon.species.translatedName else Text.translatable("cobblemon.entity.pokemon"),
+                coords.x,
+                coords.y,
+                coords.z
             ) else ""
         )
     }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
@@ -15,6 +15,7 @@ class SpawnNotificationConfig {
     val broadcastVolatileDespawns = false
     val broadcastSpeciesName = true
     val broadcastPlayerSpawnedOn = false
+    val broadcastWaypoints = false
 
     val broadcastRange: Int = -1
     val playerLimit: Int = -1

--- a/src/main/resources/assets/spawn_notification/lang/en_us.json
+++ b/src/main/resources/assets/spawn_notification/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "spawn_notification.notification.spawn": "A %1$s%2$s%3$s%4$s appeared %5$s%6$s%7$s%8$s",
+  "spawn_notification.notification.spawn": "A %1$s%2$s%3$s%4$s appeared %5$s%6$s%7$s%8$s%9$s",
   "spawn_notification.notification.despawn": "A %1$s%2$s%3$s%4$s %5$s %6$s%7$s%8$s",
 
   "spawn_notification.notification.shiny": "%1$s ",
@@ -7,8 +7,9 @@
   "spawn_notification.notification.bucket": "%1$s ",
   "spawn_notification.notification.biome": "in a %1$s ",
   "spawn_notification.notification.coords": "at %1$s, %2$s, %3$s ",
-  "spawn_notification.notification.dimension": "in %1$s",
-  "spawn_notification.notification.player": " near %1$s",
+  "spawn_notification.notification.dimension": "in %1$s ",
+  "spawn_notification.notification.player": " near %1$s ",
+  "spawn_notification.notification.waypoints": "| [name:\"%1$s%2$s%3$s%4$s\", x:%5$s, y:%6$s, z:%7$s] ",
 
   "spawn_notification.shiny": "shiny",
 


### PR DESCRIPTION
I took a crack at it, and made a functional (although sloppy) integration with JourneyMap waypoints. This is my first time doing anything like this, so I'm almost definitely missing something obvious to make it cleaner. Specifically, the reuse of half the code in getBroadcast, still within getBroadcast... I did try to create a category for .shiny, .label, .bucket, and species, allowing them all to be referenced as one, but I wasn't able to make it work reasonably. I also opted to not deal with Xaero's, though implementation would be similar, you'd just need either two different config options or to detect which mod is present.

Feel free to completely disregard this, modify it, use it, whatever! 