### PR TITLE
added blacklist for broadcast to config

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/DespawnBroadcaster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/DespawnBroadcaster.kt
@@ -1,5 +1,6 @@
 package us.timinc.mc.cobblemon.spawnnotification.broadcasters
 
+import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnDetail
 import com.cobblemon.mod.common.api.spawning.detail.SpawnPool
 import com.cobblemon.mod.common.pokemon.Pokemon
@@ -29,7 +30,11 @@ class DespawnBroadcaster(
     private val bucket
         get() = config.bucketsForBroadcast.firstOrNull { it in buckets }
     private val shouldBroadcast
-        get() = (shiny && config.broadcastShiny) || label != null || bucket != null
+        get() = ((shiny && config.broadcastShiny) || label != null || bucket != null) && config.blacklistForBroadcast.none {
+            PokemonProperties.parse(
+                it
+            ).matches(pokemon)
+        }
 
     fun getBroadcast(): Text? {
         if (!shouldBroadcast) return null

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/SpawnBroadcaster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/SpawnBroadcaster.kt
@@ -1,5 +1,6 @@
 package us.timinc.mc.cobblemon.spawnnotification.broadcasters
 
+import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnDetail
 import com.cobblemon.mod.common.api.spawning.detail.SpawnPool
 import com.cobblemon.mod.common.pokemon.Pokemon
@@ -29,7 +30,11 @@ class SpawnBroadcaster(
     private val bucket
         get() = config.bucketsForBroadcast.firstOrNull { it in buckets }
     private val shouldBroadcast
-        get() = (shiny && config.broadcastShiny) || label != null || bucket != null
+        get() = ((shiny && config.broadcastShiny) || label != null || bucket != null) && config.blacklistForBroadcast.none {
+            PokemonProperties.parse(
+                it
+            ).matches(pokemon)
+        }
 
     fun getBroadcast(): List<Text> {
         if (!shouldBroadcast) return emptyList()

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
@@ -24,6 +24,8 @@ class SpawnNotificationConfig {
     val labelsForBroadcast: MutableSet<String> = mutableSetOf("legendary")
     val bucketsForBroadcast: MutableSet<String> = mutableSetOf()
 
+    val blacklistForBroadcast: MutableSet<String> = mutableSetOf()
+
     val broadcastXaerosWaypoints
         get() = !disableWaypoints && SpawnNotification.xaerosPresent
     val broadcastJourneyMapWaypoints


### PR DESCRIPTION
add any pokemon properties string in there, and if a spawn matches it, it won't broadcast, regardless of the labelsForBroadcast, bucketsForBroadcast, or broadcastShiny settings.
