### PR TITLE
added catch-all for unbroadcasted spawns

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
@@ -13,6 +13,10 @@ import us.timinc.mc.cobblemon.spawnnotification.events.*
 
 object SpawnNotification : ModInitializer {
     const val MOD_ID = "spawn_notification"
+    const val SPAWN_BROADCASTED = "spawn_notification:spawn_broadcasted"
+    const val BUCKET = "spawn_notification:bucket"
+    const val FAINT_HAS_ENTITY = "spawn_notification:faint_reason"
+    const val FAINT_ENTITY = "spawn_notification:faint_entity"
     var config: SpawnNotificationConfig = ConfigBuilder.load(SpawnNotificationConfig::class.java, MOD_ID)
     var journeyMapPresent: Boolean = false
     var xaerosPresent: Boolean = false
@@ -31,6 +35,7 @@ object SpawnNotification : ModInitializer {
         CobblemonEvents.POKEMON_CAPTURED.subscribe(Priority.LOWEST, BroadcastCapture::handle)
         CobblemonEvents.POKEMON_FAINTED.subscribe(Priority.LOWEST, BroadcastFaint::handle)
         CobblemonEvents.BATTLE_FAINTED.subscribe(Priority.LOWEST, BroadcastFaint::handle)
+        ServerEntityEvents.ENTITY_LOAD.register(BroadcastUnnaturalSpawn::handle)
         ServerEntityEvents.ENTITY_UNLOAD.register(BroadcastFaint::handle)
         ServerEntityEvents.ENTITY_UNLOAD.register(BroadcastDespawn::handle)
         ServerLifecycleEvents.END_DATA_PACK_RELOAD.register { _, _, _ ->

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/CaptureBroadcaster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/CaptureBroadcaster.kt
@@ -6,8 +6,8 @@ import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.BUCKET
 import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
-import us.timinc.mc.cobblemon.spawnnotification.events.AttachBucket.BUCKET
 
 class CaptureBroadcaster(
     val pokemon: Pokemon,

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/DespawnBroadcaster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/DespawnBroadcaster.kt
@@ -5,8 +5,8 @@ import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.text.Text
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.BUCKET
 import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
-import us.timinc.mc.cobblemon.spawnnotification.events.AttachBucket.BUCKET
 
 class DespawnBroadcaster(
     val pokemon: Pokemon,

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/FaintBroadcaster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/FaintBroadcaster.kt
@@ -6,8 +6,8 @@ import net.minecraft.entity.Entity
 import net.minecraft.text.Text
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.BUCKET
 import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
-import us.timinc.mc.cobblemon.spawnnotification.events.AttachBucket.BUCKET
 
 class FaintBroadcaster(
     val pokemon: Pokemon,

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/SpawnBroadcaster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/broadcasters/SpawnBroadcaster.kt
@@ -6,8 +6,8 @@ import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.BUCKET
 import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
-import us.timinc.mc.cobblemon.spawnnotification.events.AttachBucket.BUCKET
 
 class SpawnBroadcaster(
     val pokemon: Pokemon,

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/AttachBucket.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/AttachBucket.kt
@@ -2,9 +2,9 @@ package us.timinc.mc.cobblemon.spawnnotification.events
 
 import com.cobblemon.mod.common.api.events.entity.SpawnEvent
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.BUCKET
 
 object AttachBucket {
-    const val BUCKET = "spawn_notification:bucket"
     fun handle(evt: SpawnEvent<PokemonEntity>) {
         evt.entity.pokemon.persistentData.putString(BUCKET, evt.ctx.cause.bucket.name)
     }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/BroadcastDespawn.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/BroadcastDespawn.kt
@@ -6,9 +6,9 @@ import net.minecraft.entity.Entity
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.FAINT_HAS_ENTITY
 import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
 import us.timinc.mc.cobblemon.spawnnotification.broadcasters.DespawnBroadcaster
-import us.timinc.mc.cobblemon.spawnnotification.events.BroadcastFaint.FAINT_HAS_ENTITY
 import us.timinc.mc.cobblemon.spawnnotification.util.Broadcast
 import us.timinc.mc.cobblemon.spawnnotification.util.PlayerUtil.getValidPlayers
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/BroadcastFaint.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/BroadcastFaint.kt
@@ -10,14 +10,14 @@ import net.minecraft.entity.Entity
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.FAINT_ENTITY
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.FAINT_HAS_ENTITY
 import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
 import us.timinc.mc.cobblemon.spawnnotification.broadcasters.FaintBroadcaster
 import us.timinc.mc.cobblemon.spawnnotification.util.Broadcast
 import us.timinc.mc.cobblemon.spawnnotification.util.PlayerUtil.getValidPlayers
 
 object BroadcastFaint {
-    const val FAINT_HAS_ENTITY = "spawn_notification:faint_reason"
-    const val FAINT_ENTITY = "spawn_notification:faint_entity"
 
     fun handle(evt: PokemonFaintedEvent) {
         if (!config.broadcastFaints) return

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/BroadcastSpawn.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/BroadcastSpawn.kt
@@ -3,6 +3,7 @@ package us.timinc.mc.cobblemon.spawnnotification.events
 import com.cobblemon.mod.common.api.events.entity.SpawnEvent
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawner
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.SPAWN_BROADCASTED
 import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
 import us.timinc.mc.cobblemon.spawnnotification.broadcasters.SpawnBroadcaster
 import us.timinc.mc.cobblemon.spawnnotification.util.Broadcast
@@ -16,6 +17,8 @@ object BroadcastSpawn {
 
         if (world.isClient) return
         if (pokemon.isPlayerOwned()) return
+
+        pokemon.persistentData.putBoolean(SPAWN_BROADCASTED, true)
 
         val messages = SpawnBroadcaster(
             evt.entity.pokemon,

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/BroadcastUnnaturalSpawn.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/events/BroadcastUnnaturalSpawn.kt
@@ -1,0 +1,43 @@
+package us.timinc.mc.cobblemon.spawnnotification.events
+
+import com.cobblemon.mod.common.api.scheduling.afterOnServer
+import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
+import net.minecraft.entity.Entity
+import net.minecraft.server.world.ServerWorld
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.SPAWN_BROADCASTED
+import us.timinc.mc.cobblemon.spawnnotification.SpawnNotification.config
+import us.timinc.mc.cobblemon.spawnnotification.broadcasters.SpawnBroadcaster
+import us.timinc.mc.cobblemon.spawnnotification.util.Broadcast
+import us.timinc.mc.cobblemon.spawnnotification.util.PlayerUtil.getValidPlayers
+
+object BroadcastUnnaturalSpawn {
+    fun handle(entity: Entity, world: ServerWorld) {
+        if (entity !is PokemonEntity) return
+        val pokemon = entity.pokemon
+
+        if (pokemon.isPlayerOwned()) return
+
+        afterOnServer(1, world) {
+            if (pokemon.persistentData.contains(SPAWN_BROADCASTED)) return@afterOnServer
+
+            val pos = entity.blockPos
+
+            val messages = SpawnBroadcaster(
+                pokemon,
+                pos,
+                world.biomeAccess.getBiome(pos).key.get().value,
+                world.dimensionEntry.key.get().value,
+                null
+            ).getBroadcast()
+            messages.forEach { message ->
+                if (config.announceCrossDimensions) {
+                    Broadcast.broadcastMessage(message)
+                } else if (config.broadcastRangeEnabled) {
+                    Broadcast.broadcastMessage(getValidPlayers(world.dimensionEntry.key.get(), pos), message)
+                } else {
+                    Broadcast.broadcastMessage(world, message)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Pokemon now get marked as broadcast, and after a tick, if they weren't, they go through a catch-all
* moved constants into mod file
