### PR TITLE
fix mistake in isReallyWild

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ archives_base_name=spawnnotification
 # Dependencies
 fabric_version=0.114.0+1.21.1
 fabric_kotlin_version=1.9.3+kotlin.1.8.20
-cobblemon_version=1.6.0+1.21.1
+cobblemon_version=1.6.1+1.21.1
 journeymap_version=1.21.1-6.0.0-beta.39+fabric
 xaeros-minimap_version=25.1.0_Fabric_1.21
 xaeros-world-map_version=1.39.4_Fabric_1.21

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PokemonExtensions.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PokemonExtensions.kt
@@ -2,4 +2,4 @@ package us.timinc.mc.cobblemon.spawnnotification.util
 
 import com.cobblemon.mod.common.pokemon.Pokemon
 
-fun Pokemon.isReallyWild() = this.isWild() || this.originalTrainer != null
+fun Pokemon.isReallyWild() = this.isWild() && this.originalTrainer === null


### PR DESCRIPTION
Pokémon are wild if Cobblemon says so *and* there is no original trainer tagged, not *or* there *is* an original trainer
